### PR TITLE
グラフの見た目を修正

### DIFF
--- a/src/presentation/components/prefecturesPopulationGraphByYear.tsx
+++ b/src/presentation/components/prefecturesPopulationGraphByYear.tsx
@@ -21,10 +21,10 @@ export const PrefecturesPopulationGraphByYear = (props: Props) => {
       {props.selectedPrefCodeList.length === 0 && <p>人口を表示する県を選択してください</p>}
       {props.prefecturesPopulationData.isLoading && <p>ロード中</p>}
       {props.selectedPrefCodeList.length > 0 && !props.prefecturesPopulationData.isLoading && (
-        <LineChart width={730} height={250} data={data} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
+        <LineChart width={730} height={250} data={data} margin={{ top: 5, right: 30, left: 50, bottom: 5 }}>
           <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="year" />
-          <YAxis />
+          <XAxis dataKey="year" unit="年" />
+          <YAxis unit="人" />
           <Tooltip />
           <Legend />
           {selectedPrefNames.map((selectedPrefName, i) => (

--- a/src/presentation/components/prefecturesPopulationGraphByYear.tsx
+++ b/src/presentation/components/prefecturesPopulationGraphByYear.tsx
@@ -12,6 +12,10 @@ type Props = {
 
 export const PrefecturesPopulationGraphByYear = (props: Props) => {
   const [data, selectedPrefNames] = convertFromPrefecturesPopulationData(props)
+
+  // TODO グラフコンポーネントが増えるようなら, useContext で各コンポーネントに配りたい
+  const colors = ['#C55859', '#F08C57', '#F2DA48', '#48C176', '#4C9CD7', '#8A69B6']
+
   return (
     <>
       {props.selectedPrefCodeList.length === 0 && <p>人口を表示する県を選択してください</p>}
@@ -24,7 +28,7 @@ export const PrefecturesPopulationGraphByYear = (props: Props) => {
           <Tooltip />
           <Legend />
           {selectedPrefNames.map((selectedPrefName, i) => (
-            <Line key={i} dataKey={selectedPrefName} stroke="#8884d8" />
+            <Line key={i} dataKey={selectedPrefName} stroke={colors[i % colors.length]} />
           ))}
         </LineChart>
       )}


### PR DESCRIPTION
## 概要

- 雑にカラフルに
  - とりあえず、視認性が良さそうな6色をピックアップして、ローテーションさせている
- 流石になんのグラフか分からなかったので、軸に単位を付けた
  - recharts のドキュメントを熟読できていないので、もっといい方法があるかもしれない(軸に対して"(年)"のように単位を表示したかったが、現状は各ラベルに単位が追加されている)

## SS

![スクリーンショット 2021-03-24 13 49 12](https://user-images.githubusercontent.com/22994051/112257165-c2c43e00-8ca7-11eb-9742-46e25a9dd75f.png)
